### PR TITLE
feat: non-blocking message-wait long-poll endpoint

### DIFF
--- a/claude_crew/server.py
+++ b/claude_crew/server.py
@@ -59,11 +59,15 @@ def make_server(
     factory: TeammateFactory | None = None,
     home_dir: Path | None = None,
     project_root: Path | None = None,
+    ui_port: int | None = None,
 ) -> FastMCP:
     # Capture project_root once at server creation time so list_available_tools
     # returns a stable value for the process lifetime.
     _project_root: Path = project_root if project_root is not None else Path.cwd()
     _home_dir: Path | None = home_dir  # None → discovery functions use Path.home()
+    # Resolved UI port for the non-blocking message-wait endpoint. None or <= 0
+    # means the UI server is disabled, so get_wait_endpoint reports no URL.
+    _ui_port: int | None = ui_port
     if factory is None:
         # Lazy import to avoid circular: factories imports server's siblings.
         from claude_crew.factories import default_factory
@@ -106,7 +110,14 @@ def make_server(
             "In-session subagents already run in parallel.\n\n"
             "Pattern: claude-crew for *relationship* (persistence + dialog + "
             "memory) and *recursive delegation* (teammate spawning its own "
-            "helpers). In-session subagents for fire-and-forget specialist work."
+            "helpers). In-session subagents for fire-and-forget specialist "
+            "work.\n\n"
+            "Staying productive while waiting: get_messages long-polls and "
+            "blocks your turn. To keep working instead of waiting idle, call "
+            "get_wait_endpoint for a localhost URL, then background a "
+            "`curl` long-poll against it via the Bash tool "
+            "(run_in_background=true) — it returns the instant a teammate "
+            "replies, and you drain the content via get_messages."
         ),
     )
 
@@ -250,6 +261,18 @@ def make_server(
         that returns as soon as a teammate replies, instead of repeated
         immediate-return polls that waste lead-session turns and context.
 
+        Staying productive while waiting: this call blocks the lead's turn.
+        When you have other work to do instead of waiting idle, you have two
+        options. (1) Cheapest: pass a SMALL wait_seconds (e.g. 5) and the
+        next-poll cursor (next_seq) — drain what's queued, do a chunk of work,
+        poll again next turn. (2) True push-on-arrival without freezing: call
+        get_wait_endpoint to get a localhost URL, then run, via the Bash tool
+        with run_in_background=true, a blocking long-poll against it, e.g.
+        `curl -s "<url>?since_seq=<next_seq>&timeout=300"`. That curl returns
+        the instant a message lands; the harness notifies you, and you then
+        call this tool to drain. The endpoint is content-free (signals arrival
+        only); actual message content always comes back through THIS tool.
+
         Choosing wait_seconds:
         - Awaiting a reply to something you just sent: 300 (5 min) is
           a sensible default. Bump higher (up to 600, the server cap)
@@ -284,6 +307,56 @@ def make_server(
         return {
             "messages": [m.to_dict() for m in msgs],
             "next_seq": next_seq,
+        }
+
+    @mcp.tool()
+    async def get_wait_endpoint() -> dict[str, Any]:
+        """Return the localhost URL for the non-blocking message-wait long-poll.
+
+        Use this to stay productive instead of blocking on get_messages. The
+        returned URL is an HTTP long-poll that BLOCKS until the lead has a new
+        message, then returns a content-free arrival signal (no payloads).
+
+        Pattern:
+          1. Call this once; cache the URL.
+          2. Run, via the Bash tool with run_in_background=true:
+             `curl -s "<url>?since_seq=<next_seq>&timeout=300"`
+             (since_seq = the next_seq from your last get_messages call).
+          3. Keep working. When a teammate replies the curl returns and the
+             harness notifies you.
+          4. Call get_messages to drain the actual content, then relaunch the
+             curl with the new next_seq.
+
+        Query params on the URL: ``since_seq`` (cursor; default 0) and
+        ``timeout`` (seconds to block; default 300, capped at 600 server-side).
+        Response JSON: ``{waiting, count, next_seq}``.
+
+        Returns ``{enabled: false, url: null, ...}`` when the UI/HTTP server is
+        disabled (CLAUDE_CREW_UI_PORT=0) — fall back to a small-wait_seconds
+        get_messages poll in that case.
+        """
+        # Invariant: production threads in the *resolved* port (main() reads it
+        # via getsockname() before calling make_server), so a live UI is always
+        # > 0 here. _ui_port of None (tests / make_server default) or 0 (UI
+        # disabled via CLAUDE_CREW_UI_PORT=0) both mean "no endpoint".
+        if _ui_port is None or _ui_port <= 0:
+            return {
+                "enabled": False,
+                "url": None,
+                "reason": (
+                    "HTTP server disabled (CLAUDE_CREW_UI_PORT=0); use "
+                    "get_messages with a small wait_seconds to poll instead."
+                ),
+            }
+        return {
+            "enabled": True,
+            "url": f"http://127.0.0.1:{_ui_port}/wait-messages",
+            "usage": (
+                'background a Bash call: '
+                f'curl -s "http://127.0.0.1:{_ui_port}/wait-messages'
+                '?since_seq=<next_seq>&timeout=300" — it returns when a '
+                "message arrives; then call get_messages to drain."
+            ),
         }
 
     @mcp.tool()
@@ -504,7 +577,7 @@ def main() -> None:
             ui_port = 0
 
     broker = Broker()
-    server = make_server(broker=broker)
+    server = make_server(broker=broker, ui_port=ui_port)
 
     if ui_port <= 0:
         if ui_sock:

--- a/claude_crew/ui_server.py
+++ b/claude_crew/ui_server.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import math
 import os
 import subprocess
 import time
@@ -24,7 +25,7 @@ from starlette.responses import HTMLResponse, JSONResponse
 from starlette.routing import Route, WebSocketRoute
 from starlette.websockets import WebSocket, WebSocketDisconnect
 
-from claude_crew.broker import Broker, BrokerSnapshot
+from claude_crew.broker import LEAD_ID, Broker, BrokerSnapshot
 from claude_crew.instance_registry import InstanceRegistry
 from claude_crew.teammate import ToolEvent
 
@@ -34,6 +35,23 @@ _DASHBOARD_PATH = Path(__file__).parent / "ui" / "dashboard.html"
 _POLL_INTERVAL = 1.5
 _BRANCH_TTL_SECONDS = 30
 _BRANCH_DETECT_TIMEOUT = 2.0
+# Server-side cap on the /wait-messages long-poll, mirroring the MCP
+# get_messages tool's MAX_WAIT_SECONDS. A caller-supplied timeout above this
+# is clamped before it reaches the broker.
+_WAIT_MESSAGES_MAX_TIMEOUT = 600.0
+# Ceiling on concurrent in-flight /wait-messages long-polls per UIServer.
+# The realistic caller is a single lead backgrounding one curl at a time;
+# this is a backstop so a buggy/looping caller can't pile up parked tasks.
+# Above the ceiling the endpoint returns 429 rather than parking another waiter.
+_WAIT_MESSAGES_MAX_INFLIGHT = 32
+
+# Threat-model note for /wait-messages (v1): the endpoint is bound to localhost
+# only (see serve()) and is content-free — it returns {waiting, count, next_seq},
+# never message payloads. No auth token is required on the rationale that a
+# single-user dev machine's localhost is trusted. `count`/`next_seq` do disclose
+# message *volume/arrival cadence* (not content) to any local process; on a
+# shared/CI host that metadata leak would warrant an auth token. Revisit the
+# no-auth decision if this is ever deployed beyond a single-user workstation.
 
 
 def _normalize_model(model_id: str | None) -> str:
@@ -132,6 +150,10 @@ class UIServer:
         self._sock = sock  # pre-bound socket; closed in serve() finally block
         self._cwd = cwd if cwd is not None else os.getcwd()
         self._branch_cache: tuple[str, float] = ("main", 0.0)
+        # Count of concurrently parked /wait-messages long-polls (M-2 backstop).
+        # Safe as a plain int: asyncio is single-threaded and the check→increment
+        # in _handle_wait_messages has no await between them.
+        self._wait_inflight: int = 0
         # Long-lived client: connection pooling across push cycles.
         # Closed in serve()'s finally block.
         self._http_client = httpx.AsyncClient(timeout=2.0)
@@ -459,10 +481,106 @@ class UIServer:
         except Exception:
             _logger.exception("UI WebSocket error; connection closed")
 
+    async def _wait_messages(self, since_seq: int, timeout: float) -> dict[str, Any]:
+        """Content-free long-poll: block until the lead has mail past since_seq.
+
+        Composes the broker's existing primitives — get_messages (the level
+        check) and wait_for_lead_message (the block) — and returns ONLY a signal:
+        ``{waiting, count, next_seq}``. No message payloads cross this boundary;
+        the lead drains actual content via the get_messages MCP tool.
+
+        Level-triggered by construction (D1): the leading get_messages check
+        returns immediately when mail already sits past since_seq, closing the
+        lost-wakeup race where a message lands after the lead drains but before
+        the next waiter parks on the Condition. The post-wait re-check mirrors
+        the MCP get_messages tool exactly.
+
+        The caller's timeout is clamped to _WAIT_MESSAGES_MAX_TIMEOUT so an
+        unbounded value cannot pin a connection open indefinitely.
+        """
+        msgs = self._broker.get_messages(recipient=LEAD_ID, since_seq=since_seq)
+        if not msgs:
+            capped = min(timeout, _WAIT_MESSAGES_MAX_TIMEOUT)
+            await self._broker.wait_for_lead_message(capped)
+            msgs = self._broker.get_messages(recipient=LEAD_ID, since_seq=since_seq)
+        next_seq = msgs[-1].seq if msgs else since_seq
+        return {"waiting": bool(msgs), "count": len(msgs), "next_seq": next_seq}
+
+    async def _handle_wait_messages(self, request: Request) -> JSONResponse:
+        """HTTP boundary for the message-wait long-poll.
+
+        Parses ``since_seq`` (default 0) and ``timeout`` (default 300s) query
+        params, returning 400 on malformed/out-of-range values, then delegates
+        to _wait_messages. Localhost-only by binding (see serve()); the response
+        is content-free so no auth token is required in v1 (see threat-model
+        note at module top).
+
+        Validation hardening:
+        - since_seq must parse as int and be >= 0 (a negative cursor would make
+          get_messages return the entire log).
+        - timeout must parse as a finite number >= 0. ``float("nan")`` and
+          ``float("inf")`` parse successfully but would poison the clamp /
+          detonate inside asyncio.timeout(); reject them up front. timeout == 0
+          is allowed and means a non-blocking peek (pure level-check).
+        - Above _WAIT_MESSAGES_MAX_INFLIGHT concurrent waiters → 429.
+        - Any unexpected error → structured 500 (mirrors _handle_state) so a
+          backgrounded curl always gets parseable JSON, never a bare stack page.
+        """
+        try:
+            raw_since = request.query_params.get("since_seq", "0")
+            try:
+                since_seq = int(raw_since)
+            except ValueError:
+                return JSONResponse(
+                    {"error": f"since_seq must be an integer, got {raw_since!r}"},
+                    status_code=400,
+                )
+            if since_seq < 0:
+                return JSONResponse(
+                    {"error": f"since_seq must be >= 0, got {since_seq}"},
+                    status_code=400,
+                )
+
+            raw_timeout = request.query_params.get("timeout", "300")
+            try:
+                timeout = float(raw_timeout)
+            except ValueError:
+                return JSONResponse(
+                    {"error": f"timeout must be a number, got {raw_timeout!r}"},
+                    status_code=400,
+                )
+            if not math.isfinite(timeout) or timeout < 0:
+                return JSONResponse(
+                    {"error": f"timeout must be a finite number >= 0, got {raw_timeout!r}"},
+                    status_code=400,
+                )
+
+            if self._wait_inflight >= _WAIT_MESSAGES_MAX_INFLIGHT:
+                return JSONResponse(
+                    {
+                        "error": "too_many_waiters",
+                        "message": (
+                            f"at most {_WAIT_MESSAGES_MAX_INFLIGHT} concurrent "
+                            "/wait-messages long-polls are allowed"
+                        ),
+                    },
+                    status_code=429,
+                )
+
+            self._wait_inflight += 1
+            try:
+                return JSONResponse(await self._wait_messages(since_seq, timeout))
+            finally:
+                self._wait_inflight -= 1
+        except Exception:
+            _logger.exception("wait-messages handler error")
+            return JSONResponse({"error": "internal_error"}, status_code=500)
+
     def _make_app(self) -> Starlette:
         return Starlette(routes=[
             Route("/", self._handle_root),
             Route("/api/state", self._handle_state),
+            Route("/wait-messages", self._handle_wait_messages),
             WebSocketRoute("/ws", self._handle_ws),
         ])
 
@@ -471,6 +589,12 @@ class UIServer:
             self._registry.register()
         try:
             if self._sock is not None:
+                # The fd= path inherits whatever address the pre-bound socket
+                # holds. _bind_ui_socket (server.py) binds 127.0.0.1, so the
+                # effective host stays localhost — load-bearing for the
+                # /wait-messages localhost-only guarantee. If that bind ever
+                # changes to 0.0.0.0, this path would silently follow; add an
+                # explicit guard there before doing so.
                 config = uvicorn.Config(
                     self._make_app(),
                     fd=self._sock.fileno(),

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -177,6 +177,38 @@ class TestGetMessagesTool:
             assert len(filtered["messages"]) == 2
 
 
+# ---------- get_wait_endpoint ----------
+
+class TestGetWaitEndpointTool:
+    """get_wait_endpoint reports the localhost URL the lead curls to long-poll
+    for message arrival out-of-process (backgrounded Bash), then drains via the
+    existing get_messages MCP tool. Content-free: the URL only signals arrival.
+    """
+
+    async def test_returns_url_when_ui_enabled(self) -> None:
+        server = make_server(ui_port=12345)
+        async with create_connected_server_and_client_session(server) as s:
+            await s.initialize()
+            body = _content_json(await s.call_tool("get_wait_endpoint", {}))
+            assert body["enabled"] is True
+            assert body["url"] == "http://127.0.0.1:12345/wait-messages"
+
+    async def test_reports_disabled_when_ui_port_absent(self) -> None:
+        async with _client() as s:
+            await s.initialize()
+            body = _content_json(await s.call_tool("get_wait_endpoint", {}))
+            assert body["enabled"] is False
+            assert body["url"] is None
+
+    async def test_reports_disabled_when_ui_port_zero(self) -> None:
+        server = make_server(ui_port=0)
+        async with create_connected_server_and_client_session(server) as s:
+            await s.initialize()
+            body = _content_json(await s.call_tool("get_wait_endpoint", {}))
+            assert body["enabled"] is False
+            assert body["url"] is None
+
+
 # ---------- list_crew ----------
 
 class TestListCrewTool:

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -1,20 +1,33 @@
 """Tests for claude_crew.ui_server — UIServer, _build_state, helpers."""
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 from starlette.testclient import TestClient
 
 import subprocess
 
-from claude_crew.broker import Broker
+from claude_crew.broker import LEAD_ID, Broker
+from claude_crew.envelope import Envelope, new_message_id
 from claude_crew.ui_server import (
     UIServer,
     _BRANCH_TTL_SECONDS,
+    _WAIT_MESSAGES_MAX_INFLIGHT,
+    _WAIT_MESSAGES_MAX_TIMEOUT,
     _derive_status,
     _normalize_model,
     _ts,
     _unreachable_instance,
 )
+
+
+def _lead_envelope(payload: str = "hi", sender: str = "t-1") -> Envelope:
+    """A teammate→lead envelope for seeding the broker in wait-endpoint tests."""
+    return Envelope(
+        id=new_message_id(), seq=0, sender=sender,
+        recipient=LEAD_ID, timestamp=0.0, payload=payload,
+    )
 
 
 # ── helpers ─────────────────────────────────────────────────────────────────
@@ -1754,3 +1767,231 @@ class TestDeadTeammateWithConfigInWsPayload:
         assert entry["cost"] == 0.05
         assert entry["tokens"]["in"] == 1000
         assert entry["tokens"]["out"] == 500
+
+
+# ── non-blocking message wait (/wait-messages long-poll) ─────────────────────
+
+
+class TestWaitMessagesLogic:
+    """Async logic layer for the content-free message-wait long-poll.
+
+    _wait_messages composes broker.get_messages (the level check) with
+    broker.wait_for_lead_message (the block), returning only a content-free
+    signal: {waiting, count, next_seq}. No message payloads cross this boundary.
+    """
+
+    async def test_returns_immediately_when_mail_already_waiting(self):
+        """Happy: a message is already in the log → return without blocking."""
+        broker = Broker()
+        await broker.send(_lead_envelope("hi"))
+        ui = UIServer(broker, port=0)
+        result = await asyncio.wait_for(
+            ui._wait_messages(since_seq=0, timeout=300), timeout=1.0
+        )
+        assert result == {"waiting": True, "count": 1, "next_seq": 1}
+
+    async def test_level_triggered_sees_message_past_since_seq(self):
+        """Lost-wakeup guard: two messages already logged, lead consumed seq=1.
+
+        A waiter starting with since_seq=1 must immediately see seq=2 even though
+        the Condition fired *before* the wait began — the leading get_messages
+        level-check is what makes this race-free.
+        """
+        broker = Broker()
+        await broker.send(_lead_envelope("first"))
+        await broker.send(_lead_envelope("second"))
+        ui = UIServer(broker, port=0)
+        result = await asyncio.wait_for(
+            ui._wait_messages(since_seq=1, timeout=300), timeout=1.0
+        )
+        assert result == {"waiting": True, "count": 1, "next_seq": 2}
+
+    async def test_blocks_then_wakes_on_arrival(self):
+        """Happy long-poll: parked on the Condition, wakes when a message lands."""
+        broker = Broker()
+        ui = UIServer(broker, port=0)
+        wait_task = asyncio.create_task(ui._wait_messages(since_seq=0, timeout=30))
+        await asyncio.sleep(0.05)  # let the waiter park on the Condition
+        assert not wait_task.done()
+        await broker.send(_lead_envelope("late"))
+        result = await asyncio.wait_for(wait_task, timeout=1.0)
+        assert result == {"waiting": True, "count": 1, "next_seq": 1}
+
+    async def test_timeout_returns_not_waiting(self):
+        """Sad: empty broker, short timeout → content-free no-mail signal."""
+        broker = Broker()
+        ui = UIServer(broker, port=0)
+        result = await asyncio.wait_for(
+            ui._wait_messages(since_seq=0, timeout=0.1), timeout=2.0
+        )
+        assert result == {"waiting": False, "count": 0, "next_seq": 0}
+
+    async def test_timeout_preserves_since_seq_in_next_seq(self):
+        """Sad: no new mail past since_seq → next_seq echoes the caller's cursor."""
+        broker = Broker()
+        ui = UIServer(broker, port=0)
+        result = await asyncio.wait_for(
+            ui._wait_messages(since_seq=5, timeout=0.1), timeout=2.0
+        )
+        assert result == {"waiting": False, "count": 0, "next_seq": 5}
+
+    async def test_caps_timeout_at_max(self, monkeypatch):
+        """An unbounded caller timeout is capped before reaching the broker."""
+        broker = Broker()
+        ui = UIServer(broker, port=0)
+        captured: dict[str, float] = {}
+
+        async def fake_wait(timeout: float) -> None:
+            captured["timeout"] = timeout
+
+        monkeypatch.setattr(broker, "wait_for_lead_message", fake_wait)
+        await ui._wait_messages(since_seq=0, timeout=99999.0)
+        assert captured["timeout"] == _WAIT_MESSAGES_MAX_TIMEOUT
+
+
+class TestWaitMessagesHttp:
+    """HTTP layer for /wait-messages — param parsing, defaults, status codes.
+
+    Behavioral guarantees (block/wake/race) are covered at the logic layer
+    above; these tests assert the route wires params through and shapes the
+    JSON response correctly. All use short/timeout paths so no test blocks.
+    """
+
+    @pytest.fixture
+    def client(self):
+        broker = Broker()
+        ui = UIServer(broker, port=0)
+        with TestClient(ui._make_app()) as c:
+            yield c
+
+    def test_route_returns_json_shape_on_timeout(self, client):
+        resp = client.get("/wait-messages?since_seq=0&timeout=0.1")
+        assert resp.status_code == 200
+        assert "application/json" in resp.headers["content-type"]
+        assert resp.json() == {"waiting": False, "count": 0, "next_seq": 0}
+
+    def test_route_parses_since_seq(self, client):
+        resp = client.get("/wait-messages?since_seq=7&timeout=0.1")
+        assert resp.status_code == 200
+        assert resp.json()["next_seq"] == 7
+
+    def test_route_defaults_since_seq_to_zero(self, client):
+        resp = client.get("/wait-messages?timeout=0.1")
+        assert resp.status_code == 200
+        assert resp.json()["next_seq"] == 0
+
+    def test_route_bad_since_seq_returns_400(self, client):
+        resp = client.get("/wait-messages?since_seq=abc&timeout=0.1")
+        assert resp.status_code == 400
+
+    def test_route_bad_timeout_returns_400(self, client):
+        resp = client.get("/wait-messages?since_seq=0&timeout=xyz")
+        assert resp.status_code == 400
+
+    @pytest.mark.parametrize("bad", ["nan", "inf", "-inf", "Infinity", "NaN"])
+    def test_route_nonfinite_timeout_returns_400(self, client, bad):
+        """float() parses nan/inf successfully; they must be rejected before the
+        clamp (nan poisons min(), inf/nan detonate inside asyncio.timeout())."""
+        resp = client.get(f"/wait-messages?since_seq=0&timeout={bad}")
+        assert resp.status_code == 400
+
+    def test_route_negative_timeout_returns_400(self, client):
+        resp = client.get("/wait-messages?since_seq=0&timeout=-5")
+        assert resp.status_code == 400
+
+    def test_route_negative_since_seq_returns_400(self, client):
+        """A negative cursor would make get_messages return the whole log."""
+        resp = client.get("/wait-messages?since_seq=-1&timeout=0.1")
+        assert resp.status_code == 400
+
+    def test_route_zero_timeout_is_nonblocking_peek(self, client):
+        """timeout=0 is allowed — a pure level-check that returns immediately."""
+        resp = client.get("/wait-messages?since_seq=0&timeout=0")
+        assert resp.status_code == 200
+        assert resp.json() == {"waiting": False, "count": 0, "next_seq": 0}
+
+    def test_route_defaults_timeout_to_300(self, monkeypatch):
+        """Omitting timeout applies the 300s default (asserted without blocking
+        by capturing the value _wait_messages receives)."""
+        broker = Broker()
+        ui = UIServer(broker, port=0)
+        captured: dict[str, float] = {}
+
+        async def fake_wait(since_seq: int, timeout: float) -> dict:
+            captured["timeout"] = timeout
+            return {"waiting": False, "count": 0, "next_seq": since_seq}
+
+        monkeypatch.setattr(ui, "_wait_messages", fake_wait)
+        with TestClient(ui._make_app()) as c:
+            resp = c.get("/wait-messages?since_seq=0")
+            assert resp.status_code == 200
+        assert captured["timeout"] == 300.0
+
+    def test_route_rejects_when_too_many_waiters(self):
+        """At the in-flight ceiling the endpoint sheds load with 429 rather than
+        parking another waiter."""
+        broker = Broker()
+        ui = UIServer(broker, port=0)
+        ui._wait_inflight = _WAIT_MESSAGES_MAX_INFLIGHT  # saturate
+        with TestClient(ui._make_app()) as c:
+            resp = c.get("/wait-messages?since_seq=0&timeout=0.1")
+            assert resp.status_code == 429
+            assert resp.json()["error"] == "too_many_waiters"
+
+    def test_route_releases_inflight_counter_after_request(self):
+        """The try/finally returns a slot to the pool after a normal request."""
+        broker = Broker()
+        ui = UIServer(broker, port=0)
+        with TestClient(ui._make_app()) as c:
+            c.get("/wait-messages?since_seq=0&timeout=0.1")
+            c.get("/wait-messages?since_seq=0&timeout=0.1")
+        assert ui._wait_inflight == 0
+
+    def test_route_releases_inflight_counter_when_wait_raises(self):
+        """The inner finally releases the slot even when _wait_messages raises;
+        the outer except still returns a structured 500."""
+        broker = Broker()
+        ui = UIServer(broker, port=0)
+
+        async def boom(since_seq: int, timeout: float) -> dict:
+            raise RuntimeError("broker exploded")
+
+        ui._wait_messages = boom  # type: ignore[method-assign]
+        with TestClient(ui._make_app()) as c:
+            resp = c.get("/wait-messages?since_seq=0&timeout=0.1")
+            assert resp.status_code == 500
+            assert resp.json()["error"] == "internal_error"
+        assert ui._wait_inflight == 0
+
+    def test_route_blocks_then_wakes_e2e(self):
+        """End-to-end through the full HTTP stack: GET blocks, a real send wakes it.
+
+        Self-contained (not the shared fixture) so the test holds the broker
+        reference and can drive a send on the app's own event loop via the
+        TestClient portal — keeping all broker ops on a single loop.
+        """
+        import threading
+        import time as _time
+
+        broker = Broker()
+        ui = UIServer(broker, port=0)
+        with TestClient(ui._make_app()) as client:
+            result: dict[str, object] = {}
+
+            def do_get() -> None:
+                result["resp"] = client.get("/wait-messages?since_seq=0&timeout=10")
+
+            t = threading.Thread(target=do_get)
+            t.start()
+            try:
+                _time.sleep(0.2)  # let the request park on the long-poll
+                # Send on the app's own event loop via the test portal so the
+                # Condition notify and the waiter share one loop.
+                client.portal.call(broker.send, _lead_envelope("wake-e2e"))
+                t.join(timeout=5)
+                assert not t.is_alive(), "long-poll GET never returned after send"
+                body = result["resp"].json()  # type: ignore[union-attr]
+                assert body["waiting"] is True
+                assert body["count"] == 1
+            finally:
+                t.join(timeout=1)


### PR DESCRIPTION
## Summary
- Adds `GET /wait-messages` on the existing UI server so the lead can stay productive instead of blocking on the `get_messages` long-poll. The lead backgrounds a `curl` against it via the Bash tool; curl returns the instant a teammate replies, the harness notifies the lead, and the lead drains content via the existing `get_messages` MCP tool.
- **Content-free by design**: returns `{waiting, count, next_seq}`, never payloads — no redaction/secret surface crosses the new boundary.
- **Level-triggered** (`get_messages` check → `wait_for_lead_message` → re-check), reusing the broker's existing Condition; closes the lost-wakeup race. No new broker code. The `since_seq` cursor stays in the lead.
- `get_wait_endpoint` MCP tool returns the resolved localhost URL (port threaded through `make_server`); reports `enabled:false` when the UI server is disabled.
- Discoverability: `get_messages` docstring + the server `instructions` block point to the pattern.

## Security (reviewed → fixed → re-reviewed clean)
A sentinel pass found and I closed: `float("nan")` poisoning the timeout clamp (now reject non-finite/negative timeout + negative `since_seq` with 400), no exception handler (now structured 500), no concurrency cap (429 ceiling). Localhost-only bind; no auth token in v1 on a single-user-dev threat model (metadata-leak caveat documented for shared/CI hosts). Re-review found no Critical/High/Medium.

## Test plan
- [x] Async logic layer: immediate-return, level-trigger race, block-then-wake, timeout, cap
- [x] HTTP layer: param parsing, defaults, 400s (incl. nan/inf/-inf), 429 ceiling, counter release (normal + raise path)
- [x] Full-stack e2e long-poll through the HTTP server with a real send
- [x] `get_wait_endpoint` tool: enabled URL + disabled fallback
- [x] Full suite: 1076 passed, 32 skipped, 1 xfailed